### PR TITLE
Changed release workflow configuration to publish a GitHub release instead of creating a draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
           name: ${{ steps.changelog.outputs.title }}
           body_path: ${{ steps.changelog.outputs.path }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+          draft: false


### PR DESCRIPTION
Resolves #91 

[Documentation](https://docs.github.com/en/rest/releases/releases?utm_source=chatgpt.com&apiVersion=2022-11-28#create-a-release) implies that this fix should be as simple as toggling this boolean. 

Testing will be performed when releasing prod.