### PR TITLE
Fixed Publish workflow not triggering on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,30 @@
-name: Publish to PyPI.org
+name: Publish to Python Package Indices
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
+
+  workflow_dispatch:
+
 jobs:
   pypi:
-    name: Upload release to PyPI
+    name: Upload release to the Python Package Index (PyPI)
     runs-on: ubuntu-latest
     environment: release
     permissions:
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout source code
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - run: python3 -m pip install --upgrade build && python3 -m build
-      - name: Publish package distributions to PyPI
+
+      - name: Install build tools
+        run: python3 -m pip install --upgrade build
+
+      - name: Build wheel
+        run: python3 -m build
+
+      - name: Publish wheel
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This changes the workflow trigger condition to be when the tag is pushed up to GitHub instead of the "on: release" condition. I cannot get the "on: release" condition to work. Many people have issues with this trigger, and there appears to be many sources of the failure. None seem to fix it for us, but the `on: push` trigger does work.

This also cleans up the workflow and adds some better names to various steps for an easier to read Actions log.